### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/packages/nuxt/src/runtime/modules/urql/index.ts
+++ b/packages/nuxt/src/runtime/modules/urql/index.ts
@@ -108,7 +108,7 @@ export default ${options.projectNameCamelCaseWithPergel}UrqlClient((ssr) => {
   const options = selectProject.client === 'custom' ? {} : selectProject.client
   return {
     ...options,
-    exchanges: process.server ? [ssr, fetchExchange] : [cacheExchange, ssr, fetchExchange],
+    exchanges: import.meta.server ? [ssr, fetchExchange] : [cacheExchange, ssr, fetchExchange],
   }
 })
 

--- a/packages/nuxt/src/templates/urql/urql.config.ts
+++ b/packages/nuxt/src/templates/urql/urql.config.ts
@@ -16,7 +16,7 @@ import { useRequestHeaders } from '#app'
 export default ${data.projectNameCamelCaseWithPergel}UrqlClient((ssr) => {
   const exchanges = [ssr, fetchExchange]
 
-  if (process.client) {
+  if (import.meta.client) {
     // configure urql graphcache with codegen types
     const cacheConfig: GraphCacheConfig = {
       schema,

--- a/themes/pergel-auth/pergel/urql-changeName/urql.config.ts
+++ b/themes/pergel-auth/pergel/urql-changeName/urql.config.ts
@@ -8,7 +8,7 @@ import { useRequestHeaders } from '#app'
 export default pergelChangeNameUrqlClient((ssr) => {
   const exchanges = [ssr, fetchExchange]
 
-  if (process.client) {
+  if (import.meta.client) {
     // configure urql graphcache with codegen types
     const cacheConfig: GraphCacheConfig = {
       schema,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->