### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/packages/nuxt/src/runtime/modules/drizzle/index.ts
+++ b/packages/nuxt/src/runtime/modules/drizzle/index.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path'
+import { relative, resolve, join } from 'node:path'
 import { execSync } from 'node:child_process'
 import { addServerImportsDir, createResolver } from '@nuxt/kit'
 import { camelCase } from 'scule'
@@ -169,6 +169,7 @@ export default definePergelModule<DrizzleConfig, ResolvedDrizzleConfig>({
     if (nuxt.options.dev) {
     // Watch for changes
       nuxt.hook('builder:watch', async (event, path) => {
+        path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
         const match = globsBuilderWatch(
           nuxt,
           path,

--- a/packages/nuxt/src/runtime/modules/drizzle/index.ts
+++ b/packages/nuxt/src/runtime/modules/drizzle/index.ts
@@ -1,4 +1,4 @@
-import { relative, resolve, join } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import { execSync } from 'node:child_process'
 import { addServerImportsDir, createResolver } from '@nuxt/kit'
 import { camelCase } from 'scule'

--- a/packages/nuxt/src/runtime/modules/graphqlYoga/utils/generateGraphqlTemplate.ts
+++ b/packages/nuxt/src/runtime/modules/graphqlYoga/utils/generateGraphqlTemplate.ts
@@ -22,7 +22,7 @@ export function generateGraphQLTemplate(data: {
 
   if (data.nuxt.options.dev) {
     data.nuxt.hook('builder:watch', async (event, path) => {
-      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
+      path = relative(data.nuxt.options.srcDir, resolve(data.nuxt.options.srcDir, path))
       const test = globsBuilderWatch(data.nuxt, path, '.graphql')
       if (!test)
         return

--- a/packages/nuxt/src/runtime/modules/graphqlYoga/utils/generateGraphqlTemplate.ts
+++ b/packages/nuxt/src/runtime/modules/graphqlYoga/utils/generateGraphqlTemplate.ts
@@ -1,4 +1,4 @@
-import { relative, resolve, join } from 'node:path'
+import { join, relative, resolve } from 'node:path'
 import { matchGlobs } from '../utils'
 import type { ResolvedGraphQLYogaConfig } from '../types'
 import type { NuxtPergel } from '../../../core/types/nuxtModule'

--- a/packages/nuxt/src/runtime/modules/graphqlYoga/utils/generateGraphqlTemplate.ts
+++ b/packages/nuxt/src/runtime/modules/graphqlYoga/utils/generateGraphqlTemplate.ts
@@ -1,4 +1,4 @@
-import { join } from 'node:path'
+import { relative, resolve, join } from 'node:path'
 import { matchGlobs } from '../utils'
 import type { ResolvedGraphQLYogaConfig } from '../types'
 import type { NuxtPergel } from '../../../core/types/nuxtModule'
@@ -22,6 +22,7 @@ export function generateGraphQLTemplate(data: {
 
   if (data.nuxt.options.dev) {
     data.nuxt.hook('builder:watch', async (event, path) => {
+      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
       const test = globsBuilderWatch(data.nuxt, path, '.graphql')
       if (!test)
         return


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.



### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->